### PR TITLE
Fix injection ordering for same-line operations

### DIFF
--- a/src/libs/sdk/sdk-impl/cmds/inject/inject-impl-mod.ts
+++ b/src/libs/sdk/sdk-impl/cmds/inject/inject-impl-mod.ts
@@ -187,6 +187,7 @@ export async function injectMultiple(
 
       // Apply all injections to the same MagicString instance
       let allSuccessful = true;
+      let currentContent = originalContent;
       for (const { config, originalIndex } of sortedConfigs) {
         const { line, column, content, createNewLine, commentsMode } = config;
 
@@ -200,12 +201,16 @@ export async function injectMultiple(
 
         const success = injectWithMagicString(
           magicString,
-          originalContent,
+          currentContent,
           line,
           column,
           preparedContent,
           createNewLine ?? false,
         );
+
+        if (success) {
+          currentContent = magicString.toString();
+        }
 
         results[originalIndex] = success
           ? { filePath, success }


### PR DESCRIPTION
## Summary
- fix injection ordering when multiple injections target the same file

## Testing
- `bun test ./.tests` *(fails: RangeError String.prototype.repeat argument must be greater than or equal to 0 and not be Infinity)*

------
https://chatgpt.com/codex/tasks/task_e_684990324e408328b010d00a338df92e